### PR TITLE
Prevent recognizing numeric values as hexes

### DIFF
--- a/Sources/hexcode/Models/ColorAsset.swift
+++ b/Sources/hexcode/Models/ColorAsset.swift
@@ -45,11 +45,16 @@ extension ColorAsset {
         var components: Components
 
         var rgbHex: String {
-            [
+            let rgb = [
                 components.red,
                 components.green,
                 components.blue
             ]
+            guard rgb.allSatisfy({
+                $0.hasPrefix("0x")
+            }) else { return "" }
+
+            return rgb
                 .reduce("", +)
                 .replacingOccurrences(of: "0x", with: "")
         }

--- a/Tests/hexcodeTests/ColorTests.swift
+++ b/Tests/hexcodeTests/ColorTests.swift
@@ -29,4 +29,23 @@ final class ColorTests: XCTestCase {
         // Then
         XCTAssertEqual(rgbHex, "F6FA0C")
     }
+
+    func test_rgbHex_withNumericComponents_isEmpty() {
+        // Given
+        let sut = SUT(
+            colorSpace: .srgb,
+            components: .init(
+                alpha: "1",
+                red: "12",
+                green: "34",
+                blue: "56"
+            )
+        )
+
+        // When
+        let rgbHex = sut.rgbHex
+
+        // Then
+        XCTAssert(rgbHex.isEmpty)
+    }
 }


### PR DESCRIPTION
In this PR:
- added one more check inside `rgbHex` method, to return empty string if components are not parts of hex

This was necessary because with only trimming of `0x`, it was possible to have single- or double-digit numeric values in 0-255 range to be falsely recognised as parts of a hex code, which would cause false positives due to actual values being different in decimal and hexadecimal systems for same numeric representations.

It will be updated in the future when support is added for conversion of numeric values into hex.