### PR TITLE
Allow lowercase hex input

### DIFF
--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -13,7 +13,9 @@ protocol ColorFinding {
 
 final class ColorFinder: ColorFinding {
     func find(_ hex: String, in colorSets: [NamedColorSet]) -> [String] {
-        let hex = hex.trimmingCharacters(in: ["#"])
+        let hex = hex
+            .trimmingCharacters(in: ["#"])
+            .uppercased()
 
         return colorSets
             .compactMap { namedSet in

--- a/Tests/hexcodeTests/ColorFinderTests.swift
+++ b/Tests/hexcodeTests/ColorFinderTests.swift
@@ -64,7 +64,7 @@ final class ColorFinderTests: XCTestCase {
 
     func test_find_trimmedHex_inColorSetsWithSingleExpectedColor_findsExpectedColor() {
         // When
-        let colors = sut.find("FFFFFF", in: [.blackColorHex, .whiteColorHex])
+        let colors = sut.find("ffffff", in: [.blackColorHex, .whiteColorHex])
 
         // Then
         XCTAssertEqual(colors, ["whiteColorHex"])


### PR DESCRIPTION
In this PR:
- allowed lowercase input for `colorHex` argument, for example `#FFFFFF` and `#ffffff` can now be used interchangeably
- updated one of the existing tests to make sure this is verified in tests