### PR TITLE
Exclude .vscode settings from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ xcuserdata/
 DerivedData/
 .swiftpm
 .netrc
+.vscode


### PR DESCRIPTION
In this PR:
- added `.vscode` settings folder to `.gitignore` to exclude it from source control