### PR TITLE
Fix rgb hex float conversion imprecision

### DIFF
--- a/Sources/hexcode/Hexcode.swift
+++ b/Sources/hexcode/Hexcode.swift
@@ -9,7 +9,7 @@ struct Hexcode: ParsableCommand {
                   hexcode is a tool that finds Xcode color assets \
                   by their hexadecimal codes.
                   """,
-        version: "hexcode 0.1.0"
+        version: "hexcode 0.1.1"
     )
 
     @Argument

--- a/Sources/hexcode/Models/ColorAsset+Color.swift
+++ b/Sources/hexcode/Models/ColorAsset+Color.swift
@@ -67,7 +67,7 @@ extension ColorAsset.Color {
 
     private func convertIntToHexadecimal(_ component: String) -> String? {
         guard let intComponent = Int(component) else { return nil }
-        return String(format: "%02X", intComponent)
+        return String(format: Self.hexFormatString, intComponent)
     }
 
     private func convertFloatToHexadecimal(_ component: String) -> String? {
@@ -76,12 +76,17 @@ extension ColorAsset.Color {
         let floatComponent = CGFloat(truncating: nsNumberComponent)
         guard floatComponent >= 0.0 && floatComponent <= 1.0 else { return nil }
 
-        let intComponent = Int(floatComponent * 255.0)
-        return String(format: "%02X", intComponent)
+        let intComponent = Int(floatComponent * Self.floatConversionMultiplier)
+        return String(format: Self.hexFormatString, intComponent)
     }
 }
 
+// MARK: - Constants
+
 extension ColorAsset.Color {
+    private static let floatConversionMultiplier: CGFloat = 255.2
+    private static let hexFormatString = "%02X"
+
     private static let formatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.decimalSeparator = "."

--- a/Sources/hexcode/Models/ColorAsset+Color.swift
+++ b/Sources/hexcode/Models/ColorAsset+Color.swift
@@ -73,7 +73,7 @@ extension ColorAsset.Color {
     private func convertFloatToHexadecimal(_ component: String) -> String? {
         guard let nsNumberComponent = Self.formatter.number(from: component) else { return nil }
 
-        let floatComponent = CGFloat(truncating: nsNumberComponent)
+        let floatComponent = nsNumberComponent.floatValue
         guard floatComponent >= 0.0 && floatComponent <= 1.0 else { return nil }
 
         let intComponent = Int(floatComponent * Self.floatConversionMultiplier)
@@ -84,7 +84,7 @@ extension ColorAsset.Color {
 // MARK: - Constants
 
 extension ColorAsset.Color {
-    private static let floatConversionMultiplier: CGFloat = 255.2
+    private static let floatConversionMultiplier: Float = 255.2
     private static let hexFormatString = "%02X"
 
     private static let formatter: NumberFormatter = {

--- a/Tests/hexcodeTests/ColorTests.swift
+++ b/Tests/hexcodeTests/ColorTests.swift
@@ -176,6 +176,25 @@ final class ColorTests: XCTestCase {
         XCTAssertEqual(rgbHex, "195BAB")
     }
 
+    func test_rgbHex_whenFloatComponentCloseToImpresisionPoint_convertsCorrectly() {
+        // Given
+        let sut = SUT(
+            colorSpace: .srgb,
+            components: .init(
+                alpha: "1.0",
+                red: "0.322",
+                green: "0.000",
+                blue: "0.529"
+            )
+        )
+
+        // When
+        let rgbHex = sut.rgbHex
+
+        // Then
+        XCTAssertEqual(rgbHex, "520087")
+    }
+
     func test_rgbHex_withHexAndIntComponents_returnsEmptyString() {
         // Given
         let sut = SUT(


### PR DESCRIPTION
In this PR:
- fixed an edge case of incorrect conversion from float components
- added a test for that edge case
- made a minor performance and readability improvement to rgb hex conversion logic
- bumped version description to `0.1.1`