### PR TITLE
Improve performance of collecting assets

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/artem-y/swifty-test-assertions.git",
       "state" : {
-        "revision" : "d1e99184b5d7b932d12bb4df90efe457117fe8d1",
-        "version" : "0.1.0"
+        "revision" : "2eaaab685e3ade033f39b2496c26ead8aa6376eb",
+        "version" : "0.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
-        .package(url: "https://github.com/artem-y/swifty-test-assertions.git", from: "0.1.0"),
+        .package(url: "https://github.com/artem-y/swifty-test-assertions.git", from: "0.1.1"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/hexcode/Controllers/AssetCollector.swift
+++ b/Sources/hexcode/Controllers/AssetCollector.swift
@@ -60,9 +60,7 @@ extension AssetCollector {
 
                     switch contentAtPath {
                     case .colorSet(let colorSet):
-                        let assetName = self.getAssetName(from: path)
-                        let namedColorSet = NamedColorSet(name: assetName, colorSet: colorSet)
-                        return [namedColorSet]
+                        return self.makeNamedColorset(from: colorSet, at: path)
 
                     case .otherDirectory(let subpaths):
                         guard !subpaths.isEmpty else { return [] }
@@ -83,6 +81,12 @@ extension AssetCollector {
         }
 
         return colorSets
+    }
+
+    private func makeNamedColorset(from colorSet: ColorSet, at path: String) -> [NamedColorSet] {
+        let assetName = getAssetName(from: path)
+        let namedColorSet = NamedColorSet(name: assetName, colorSet: colorSet)
+        return [namedColorSet]
     }
 
     private func determineContentType(at path: String) -> PathContentType? {

--- a/Sources/hexcode/Hexcode.swift
+++ b/Sources/hexcode/Hexcode.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 
 @main
-struct Hexcode: ParsableCommand {
+struct Hexcode: AsyncParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "hexcode",
@@ -28,7 +28,7 @@ struct Hexcode: ParsableCommand {
         }
     }
 
-    func run() throws {
-        try HexcodeApp().run(colorHex: colorHex, in: directory)
+    func run() async throws {
+        try await HexcodeApp().run(colorHex: colorHex, in: directory)
     }
 }

--- a/Sources/hexcode/HexcodeApp.swift
+++ b/Sources/hexcode/HexcodeApp.swift
@@ -25,9 +25,9 @@ final class HexcodeApp {
     /// - parameter colorHex: Raw input argument for hexadecimal color code.
     /// - parameter directory: Optional custom directory from user input. Defaults to current directory.
     /// - throws: All unhandled errors that can be thrown out to standard output.
-    func run(colorHex: String, in directory: String? = nil) throws {
+    func run(colorHex: String, in directory: String? = nil) async throws {
         let directory = directory ?? fileManager.currentDirectoryPath
-        let colorAssets = try assetCollector.collectAssets(in: directory)
+        let colorAssets = try await assetCollector.collectAssets(in: directory)
         let foundColors = colorFinder.find(colorHex, in: colorAssets)
 
         if foundColors.isEmpty {

--- a/Tests/hexcodeTests/AssetCollectorTests.swift
+++ b/Tests/hexcodeTests/AssetCollectorTests.swift
@@ -18,7 +18,7 @@ final class AssetCollectorTests: XCTestCase {
 
     // MARK: - Tests
 
-    func test_collectAssets_inAssetCatalogDirectory_findsAssets() throws {
+    func test_collectAssets_inAssetCatalogDirectory_findsAssets() async throws {
         // Given
         let catalogPath = "Assets.xcassets"
         setMockDirectory(at: catalogPath, with: ["whiteColorHex.colorset", "blackColorHex.colorset"])
@@ -26,13 +26,13 @@ final class AssetCollectorTests: XCTestCase {
         setMockAsset(at: catalogPath + "/blackColorHex.colorset", with: ColorSetJSON.black)
 
         // When
-        let assets = try sut.collectAssets(in: catalogPath)
+        let assets = try await sut.collectAssets(in: catalogPath)
 
         // Then
         XCTAssertEqual(assets, [.blackColorHex, .whiteColorHex])
     }
 
-    func test_collectAssets_inDicectoryWithInvalidAssets_findsNothing() throws {
+    func test_collectAssets_inDicectoryWithInvalidAssets_findsNothing() async throws {
         // Given
         let directory = "/some/directory"
 
@@ -46,35 +46,35 @@ final class AssetCollectorTests: XCTestCase {
         setMockFile(at: "\(directory)/notAColor.colorset/text.txt", with: data("hello world"))
 
         // When
-        let assets = try sut.collectAssets(in: directory)
+        let assets = try await sut.collectAssets(in: directory)
 
         // Then
         AssertEmpty(assets)
     }
 
-    func test_collectAssets_inNonExistentDirectory_throwsDirectoryNotFoundError() throws {
+    func test_collectAssets_inNonExistentDirectory_throwsDirectoryNotFoundError() async throws {
         // Given
         let path = "/nonExistentDirectory"
         mocks.fileManager.results.fileExistsAtPath[path] = nil
 
-        Assert(
-            try sut.collectAssets(in: path), // When
+        await AssertAsync(
+            try await sut.collectAssets(in: path), // When
             throwsError: SUT.Error.directoryNotFound // Then
         )
     }
 
-    func test_collectAssets_atPathThatIsFile_throwsNotADirectoryError() throws {
+    func test_collectAssets_atPathThatIsFile_throwsNotADirectoryError() async throws {
         // Given
         let filePath = "/someFile"
         mocks.fileManager.results.fileExistsAtPath[filePath] = .file
 
-        Assert(
-            try sut.collectAssets(in: filePath), // When
+        await AssertAsync(
+            try await sut.collectAssets(in: filePath), // When
             throwsError: SUT.Error.notADirectory // Then
         )
     }
 
-    func test_collectAssets_inCatalogWithMultipleSubdirectories_findsAllAssets() throws {
+    func test_collectAssets_inCatalogWithMultipleSubdirectories_findsAllAssets() async throws {
         // Given
         let catalogPath = "/Resources/AssetsInSubdirectories.xcassets"
         setMockDirectory(at: catalogPath, with: ["OtherColors", "redColorHex.colorset"])
@@ -89,7 +89,7 @@ final class AssetCollectorTests: XCTestCase {
         setMockAsset(at: "\(moreColorsDir)/blueColorHex.colorset", with: ColorSetJSON.blue)
 
         // When
-        let assets = try sut.collectAssets(in: catalogPath)
+        let assets = try await sut.collectAssets(in: catalogPath)
 
         // Then
         XCTAssertEqual(assets, [.blueColorHex, .greenColorHex, .redColorHex])

--- a/Tests/hexcodeTests/HexcodeAppTests.swift
+++ b/Tests/hexcodeTests/HexcodeAppTests.swift
@@ -37,75 +37,75 @@ final class HexcodeAppTests: XCTestCase {
 
     // MARK: - Test run
 
-    func test_run_withoutDirectory_runsInCurrentDirectoryFromFileManager() throws {
+    func test_run_withoutDirectory_runsInCurrentDirectoryFromFileManager() async throws {
         // Given
         let currentDirectory = "/currentDirectory"
         mocks.fileManager.results.currentDirectoryPath = currentDirectory
 
         // When
-        try sut.run(colorHex: "")
+        try await sut.run(colorHex: "")
 
         // Then
         XCTAssertEqual(mocks.fileManager.calls, [.getCurrentDirectoryPath])
         XCTAssertEqual(mocks.assetCollector.calls, [.collectAssetsIn(directory: currentDirectory)])
     }
 
-    func test_run_inDirectory_runsInProvidedDirectory() throws {
+    func test_run_inDirectory_runsInProvidedDirectory() async throws {
         // Given
         let searchDirectory = "/searchDirectory"
 
         // When
-        try sut.run(colorHex: "", in: searchDirectory)
+        try await sut.run(colorHex: "", in: searchDirectory)
 
         // Then
         XCTAssertEqual(mocks.assetCollector.calls, [.collectAssetsIn(directory: searchDirectory)])
     }
 
-    func test_run_whenAssetCollectorThrowsNotADirectoryError_rethrowsError() throws {
+    func test_run_whenAssetCollectorThrowsNotADirectoryError_rethrowsError() async throws {
         // Given
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.notADirectory)
 
-        Assert(
-            try sut.run(colorHex: blackHexStub), // When
+        await AssertAsync(
+            try await sut.run(colorHex: blackHexStub), // When
             throwsError: AssetCollector.Error.notADirectory // Then
         )
     }
 
-    func test_run_whenAssetCollectorThrowsDirectoryNotFound_rethrowsError() throws {
+    func test_run_whenAssetCollectorThrowsDirectoryNotFound_rethrowsError() async throws {
         // Given
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.directoryNotFound)
 
-        Assert(
-            try sut.run(colorHex: blackHexStub), // When
+        await AssertAsync(
+            try await sut.run(colorHex: blackHexStub), // When
             throwsError: AssetCollector.Error.directoryNotFound // Then
         )
     }
 
-    func test_run_whenAssetCollectorThrowsNotADirectoryError_doesNotLookForColors() {
+    func test_run_whenAssetCollectorThrowsNotADirectoryError_doesNotLookForColors() async {
         // Given
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.notADirectory)
 
         // When
-        try? sut.run(colorHex: blackHexStub)
+        try? await sut.run(colorHex: blackHexStub)
 
         // Then
         AssertEmpty(mocks.colorFinder.calls)
         AssertEmpty(mocks.outputs)
     }
 
-    func test_run_whenAssetCollectorThrowsDirectoryNotFound_doesNotLookForColors() {
+    func test_run_whenAssetCollectorThrowsDirectoryNotFound_doesNotLookForColors() async {
         // Given
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.directoryNotFound)
 
         // When
-        try? sut.run(colorHex: blackHexStub)
+        try? await sut.run(colorHex: blackHexStub)
 
         // Then
         AssertEmpty(mocks.colorFinder.calls)
         AssertEmpty(mocks.outputs)
     }
 
-    func test_run_whenCollectedAssets_callsColorFinderWithCollectedAssets() throws {
+    func test_run_whenCollectedAssets_callsColorFinderWithCollectedAssets() async throws {
         // Given
         let expectedColorSets: [NamedColorSet] = [
             .blueColorHex,
@@ -116,7 +116,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .success(expectedColorSets)
 
         // When
-        try sut.run(colorHex: colorHex)
+        try await sut.run(colorHex: colorHex)
 
         // Then
         XCTAssertEqual(
@@ -125,13 +125,13 @@ final class HexcodeAppTests: XCTestCase {
         )
     }
 
-    func test_run_whenDidNotCollectAssets_callsColorFinderWithEmptyArray() throws {
+    func test_run_whenDidNotCollectAssets_callsColorFinderWithEmptyArray() async throws {
         // Given
         let colorHex = "#F1F2F3"
         mocks.assetCollector.results.collectAssets = .success([])
 
         // When
-        try sut.run(colorHex: colorHex)
+        try await sut.run(colorHex: colorHex)
 
         // Then
         XCTAssertEqual(
@@ -140,36 +140,36 @@ final class HexcodeAppTests: XCTestCase {
         )
     }
 
-    func test_run_whenSingleColorAssetIsFound_outputsAssetName() throws {
+    func test_run_whenSingleColorAssetIsFound_outputsAssetName() async throws {
         // Given
         let expectedOutput = "white"
         mocks.colorFinder.results.find = [expectedOutput]
 
         // When
-        try sut.run(colorHex: "")
+        try await sut.run(colorHex: "")
 
         // Then
         XCTAssertEqual(mocks.outputs, [expectedOutput])
     }
 
-    func test_run_whenMultipleColorAssetIsFound_outputsAllAssetNames() throws {
+    func test_run_whenMultipleColorAssetIsFound_outputsAllAssetNames() async throws {
         // Given
         let expectedOutputs = ["red", "green", "blue"]
         mocks.colorFinder.results.find = expectedOutputs
 
         // When
-        try sut.run(colorHex: "")
+        try await sut.run(colorHex: "")
 
         // Then
         XCTAssertEqual(mocks.outputs, expectedOutputs)
     }
 
-    func test_run_whenNoColorAssetsFound_outputsNoColorsFoundMessage() throws {
+    func test_run_whenNoColorAssetsFound_outputsNoColorsFoundMessage() async throws {
         // Given
         mocks.colorFinder.results.find = []
 
         // When
-        try sut.run(colorHex: blackHexStub)
+        try await sut.run(colorHex: blackHexStub)
 
         // Then
         XCTAssertEqual(mocks.outputs, ["No \(blackHexStub) color found"])

--- a/Tests/hexcodeTests/Mocks/FileManagerMock.swift
+++ b/Tests/hexcodeTests/Mocks/FileManagerMock.swift
@@ -22,8 +22,29 @@ final class FileManagerMock: FileManager {
         var contentsAtPath: [String: Data] = [:]
     }
 
-    private(set) var calls: [Call] = []
+    private(set) var calls: [Call] {
+        get {
+            var calls: [Call] = []
+
+            let semaphore = DispatchSemaphore(value: 0)
+            operationQueue.addOperation { [weak self] in
+                calls = self?._calls ?? []
+                semaphore.signal()
+            }
+            semaphore.wait()
+            
+            return calls
+        }
+        set {
+            operationQueue.addOperation { [weak self] in
+                self?._calls = newValue
+            }
+        }
+    }
     var results = CallResults()
+
+    private var _calls: [Call] = []
+    private let operationQueue = OperationQueue()
 
     func reset() {
         calls = []


### PR DESCRIPTION
In this PR:
- bumped version of [swifty-test-assertions ](https://github.com/artem-y/swifty-test-assertions) to `0.1.1`, to enable the use of async error assertion
- put discovering and creation of `NamedColorSet` objects into a group of async tasks
- adjusted tests to work with updated async code

Overall, from what I've seen measuring the tool on a lot of repos, this made execution around x2 faster under the same conditions. Of course, there could always be a room for more improvements, optimisation in this PR is just a low-hanging fruit.