### PR TITLE
Add find-duplicates feature

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "46989693916f56d1186bd59ac15124caef896560",
-        "version" : "1.3.1"
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .macOS(.v13),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
         .package(url: "https://github.com/artem-y/swifty-test-assertions.git", from: "0.1.1"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -13,20 +13,38 @@ A tool that finds Xcode color assets by their hex codes. The idea behind this to
 ### ⚠️Disclaimer:
 For now, the tool only supports searching for exact values of color components as ints, floats or hexadecimals, without conversion between settings like content type (sRGB, Display P3, Gray Gamma 2.2 etc.), and ignoring some other settings like Gamut etc.  
 ## Usage
-The tool can be used like this from terminal:
+By default, the tool can be used from the terminal to search for matches to a given color code:
 ```
 hexcode #ffa500
 ```
 ...where `#ffa500` is a hex color code, with or without `#`, case-insensitive.  
 
-This way `hexcode` will recursively search for the color assets matching the hex rgb value, starting from current directory. The output will be one or more matching color set names, or a message notifying that it haven't found an asset with the given color. The command also has some very simple error handling and might exit with error.  
+When used this way, `hexcode` will recursively search for the color assets matching the hex rgb value, starting from the current directory. The output will be one or more matching color set names, or a message in case it haven't found an asset with the given color. Color names include path to their color asset, relative to the project. The command also has some very simple error handling and might exit with error.  
 More arguments and options will be added in the future with new features, they can be found using the `--help` flag.  
-#### Examples
+#### Default usage examples
 Color found:  
-<img width="570" alt="hexcode_usage_color_found" src="https://github.com/artem-y/hexcode/assets/52959979/708ea8d5-b38a-4c69-813b-a987a28d4242">  
+<img width="568" alt="hexcode_usage_color_found_1" src="https://github.com/user-attachments/assets/5a25b195-c981-4048-8b4b-e17b8df10a25" />
 
 Color not found:  
-<img width="570" alt="hexcode_usage_no_such_color" src="https://github.com/artem-y/hexcode/assets/52959979/77a36d4c-9480-4603-9ae2-8a6bce410a4e">
+<img width="570" alt="hexcode_usage_no_such_color" src="https://github.com/artem-y/hexcode/assets/52959979/77a36d4c-9480-4603-9ae2-8a6bce410a4e">  
+
+### Find Duplicates
+Hexcode can also check a project or a directory for duplicated color assets.
+```zsh
+hexcode find-duplicates
+```
+Output example when there are duplicates:
+```
+#24658F MyProject/Assets.xcassets/AccentColor
+#24658F MyProject/Colors.xcassets/defaultAccent
+--
+#999999 MyProject/Assets.xcassets/appColor/gray
+#999999 MyProject/Colors.xcassets/neutralGray
+```
+Output when duplicates not found:
+```
+No duplicates found
+```
 
 ## Installation
 1. Clone the repository to your machine

--- a/Sources/hexcode/Commands/FindColor.swift
+++ b/Sources/hexcode/Commands/FindColor.swift
@@ -1,15 +1,13 @@
 import ArgumentParser
 
-@main
-struct Hexcode: AsyncParsableCommand {
+struct FindColor: AsyncParsableCommand {
 
     static let configuration = CommandConfiguration(
-        commandName: "hexcode",
+        commandName: "find-color",
         abstract: """
-                  hexcode is a tool that finds Xcode color assets \
+                  Default subcommand that finds Xcode color assets \
                   by their hexadecimal codes.
-                  """,
-        version: "hexcode 0.1.1"
+                  """
     )
 
     @Argument
@@ -29,6 +27,6 @@ struct Hexcode: AsyncParsableCommand {
     }
 
     func run() async throws {
-        try await HexcodeApp().run(colorHex: colorHex, in: directory)
+        try await HexcodeApp().runFindColor(colorHex: colorHex, in: directory)
     }
 }

--- a/Sources/hexcode/Commands/FindDuplicates.swift
+++ b/Sources/hexcode/Commands/FindDuplicates.swift
@@ -1,0 +1,15 @@
+import ArgumentParser
+
+struct FindDuplicates: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "find-duplicates",
+        abstract: "Finds duplicate Xcode color assets."
+    )
+
+    @Option
+    var directory: String?
+
+    func run() async throws {
+        try await HexcodeApp().runFindDuplicates(in: directory)
+    }
+}

--- a/Sources/hexcode/Commands/Hexcode.swift
+++ b/Sources/hexcode/Commands/Hexcode.swift
@@ -1,0 +1,20 @@
+import ArgumentParser
+
+@main
+struct Hexcode: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "hexcode",
+        abstract: """
+                  hexcode is a tool that finds Xcode color assets \
+                  by their hexadecimal codes.
+                  """,
+        usage: "hexcode <color-hex> [--directory <directory>]",
+        version: "hexcode 0.1.1",
+        subcommands: [
+            FindColor.self,
+            FindDuplicates.self,
+        ],
+        defaultSubcommand: FindColor.self
+    )
+}

--- a/Sources/hexcode/Commands/Hexcode.swift
+++ b/Sources/hexcode/Commands/Hexcode.swift
@@ -10,7 +10,7 @@ struct Hexcode: AsyncParsableCommand {
                   by their hexadecimal codes.
                   """,
         usage: "hexcode <color-hex> [--directory <directory>]",
-        version: "hexcode 0.1.1",
+        version: "hexcode feature/find-duplicates",
         subcommands: [
             FindColor.self,
             FindDuplicates.self,

--- a/Sources/hexcode/Commands/Hexcode.swift
+++ b/Sources/hexcode/Commands/Hexcode.swift
@@ -10,7 +10,7 @@ struct Hexcode: AsyncParsableCommand {
                   by their hexadecimal codes.
                   """,
         usage: "hexcode <color-hex> [--directory <directory>]",
-        version: "hexcode feature/find-duplicates",
+        version: "hexcode 0.2.0",
         subcommands: [
             FindColor.self,
             FindDuplicates.self,

--- a/Sources/hexcode/Controllers/AssetCollector.swift
+++ b/Sources/hexcode/Controllers/AssetCollector.swift
@@ -105,8 +105,8 @@ extension AssetCollector {
 
     private func determineContentType(at path: String) -> PathContentType? {
         var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory) else { return nil }
-        guard isDirectory.boolValue else { return .file }
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return .file }
 
         if !path.hasSuffix(".colorset"), let subpaths = try? contents(at: path) {
             return .otherDirectory(subpaths: subpaths)
@@ -128,8 +128,8 @@ extension AssetCollector {
 
     private func readColorSet(at path: String) -> ColorSet? {
         let path = path + "/Contents.json"
-        guard let fileData = fileManager.contents(atPath: path) else { return nil }
-        guard let colorSet = try? JSONDecoder().decode(ColorSet.self, from: fileData) else { return nil }
+        guard let fileData = fileManager.contents(atPath: path),
+              let colorSet = try? JSONDecoder().decode(ColorSet.self, from: fileData) else { return nil }
         return colorSet
     }
 }

--- a/Sources/hexcode/Controllers/AssetCollector.swift
+++ b/Sources/hexcode/Controllers/AssetCollector.swift
@@ -106,17 +106,9 @@ extension AssetCollector {
     }
 
     private func getAssetName(from path: String) -> String {
-        makeURL(from: path)
+        URL(filePath: path)
             .deletingPathExtension()
             .lastPathComponent
-    }
-
-    private func makeURL(from path: String) -> URL {
-        if #available(macOS 13.0, *) {
-            return URL(filePath: path)
-        } else {
-            return URL(fileURLWithPath: path)
-        }
     }
 
     private func readColorSet(at path: String) -> ColorSet? {

--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -40,18 +40,19 @@ final class ColorFinder: ColorFinding {
         var duplicates: [String: [String]] = [:]
         let lastColorSetIndex = colorSets.count - 1
 
-        for currentColorSetIndex in colorSets.indices {
+        for currentColorSetIndex in 0...lastColorSetIndex {
             let colorSet = colorSets[currentColorSetIndex]
             let colors = colorSet.colorSet.colors
-
-            if currentColorSetIndex == lastColorSetIndex {
-                continue
-            }
+            let nextIndex = currentColorSetIndex + 1
 
             for color in colors {
-                var colorNames: [String] = []
                 let rgbHex = color.color.rgbHex
-                let nextIndex = currentColorSetIndex + 1
+
+                if duplicates.keys.contains(rgbHex) {
+                    continue
+                }
+                
+                var colorNames: [String] = []
 
                 for otherColor in colorSets[nextIndex...] {
                     let appearanceNames = findAppearances(
@@ -77,6 +78,10 @@ final class ColorFinder: ColorFinding {
                         for: rgbHex,
                         in: colors
                     )
+                    
+                    if currentColorSetAppearances.isEmpty {
+                        break
+                    }
 
                     var currentColorSetName = colorSet.name
 

--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -45,7 +45,7 @@ final class ColorFinder: ColorFinding {
             for currentColor in currentColors {
                 let rgbHex = currentColor.color.rgbHex
 
-                if duplicates.keys.contains(rgbHex) {
+                if rgbHex.isEmpty || duplicates.keys.contains(rgbHex) {
                     continue
                 }
 
@@ -74,10 +74,6 @@ final class ColorFinder: ColorFinding {
                         for: rgbHex,
                         in: currentColors
                     )
-                    
-                    if currentColorSetAppearances.isEmpty {
-                        break
-                    }
 
                     let currentColorSetName = makeColorName(
                         from: currentColorSetAppearances,

--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -5,6 +5,12 @@ protocol ColorFinding {
     /// - parameter colorSets: Color sets to check for matching hex color code.
     /// - returns: Names of color sets with matching colors. Empty if none found.
     func find(_ hex: String, in colorSets: [NamedColorSet]) -> [String]
+
+
+    /// Searches the collection of named color sets for colors matching the same hex equivalent.
+    /// - Parameter colorSets: Color sets to check for duplicate hex values.
+    /// - Returns: Hexadecimal color codes with arrays of matching color duplicates. Empty if none found.
+    func findDuplicates(in colorSets: [NamedColorSet]) -> [String: [String]]
 }
 
 final class ColorFinder: ColorFinding {
@@ -27,6 +33,10 @@ final class ColorFinder: ColorFinding {
 
                 return namedSet.name + " (\(joined(appearances)))"
             }
+    }
+
+    func findDuplicates(in colorSets: [NamedColorSet]) -> [String: [String]] {
+        [:]
     }
 }
 

--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -36,7 +36,65 @@ final class ColorFinder: ColorFinding {
     }
 
     func findDuplicates(in colorSets: [NamedColorSet]) -> [String: [String]] {
-        [:]
+
+        var duplicates: [String: [String]] = [:]
+        let lastColorSetIndex = colorSets.count - 1
+
+        for currentColorSetIndex in colorSets.indices {
+            let colorSet = colorSets[currentColorSetIndex]
+            let colors = colorSet.colorSet.colors
+
+            if currentColorSetIndex == lastColorSetIndex {
+                continue
+            }
+
+            for color in colors {
+                var colorNames: [String] = []
+                let rgbHex = color.color.rgbHex
+                let nextIndex = currentColorSetIndex + 1
+
+                for otherColor in colorSets[nextIndex...] {
+                    let appearanceNames = findAppearances(
+                        for: rgbHex,
+                        in: otherColor.colorSet.colors
+                    )
+
+                    if appearanceNames.isEmpty {
+                        continue
+                    }
+
+                    var name = otherColor.name
+
+                    if appearanceNames.count < otherColor.colorSet.colors.count {
+                        name += " (\(joined(appearanceNames)))"
+                    }
+
+                    colorNames.append(name)
+                }
+
+                if !colorNames.isEmpty {
+                    let currentColorSetAppearances = findAppearances(
+                        for: rgbHex,
+                        in: colors
+                    )
+
+                    var currentColorSetName = colorSet.name
+
+                    if currentColorSetAppearances.count < colors.count {
+                        currentColorSetName += " (\(joined(currentColorSetAppearances)))"
+                    }
+
+                    colorNames.append(currentColorSetName)
+
+                    if duplicates[rgbHex] == nil {
+                        duplicates[rgbHex] = colorNames.sorted()
+                    }
+                }
+
+            }
+        }
+
+        return duplicates
     }
 }
 

--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -35,9 +35,9 @@ final class ColorFinder: ColorFinding {
     func findDuplicates(in colorSets: [NamedColorSet]) -> [String: [String]] {
 
         var duplicates: [String: [String]] = [:]
-        let lastColorSetIndex = colorSets.count - 1
+        let colorSetCount = colorSets.count
 
-        for currentColorSetIndex in 0...lastColorSetIndex {
+        for currentColorSetIndex in 0..<colorSetCount {
             let currentColorSet = colorSets[currentColorSetIndex]
             let currentColors = currentColorSet.colorSet.colors
             let nextColorSetIndex = currentColorSetIndex + 1

--- a/Sources/hexcode/Controllers/ColorFinder.swift
+++ b/Sources/hexcode/Controllers/ColorFinder.swift
@@ -27,11 +27,8 @@ final class ColorFinder: ColorFinding {
                 guard !appearances.isEmpty else {
                     return nil
                 }
-                guard appearances.count < colors.count else {
-                    return namedSet.name
-                }
 
-                return namedSet.name + " (\(joined(appearances)))"
+                return makeColorName(from: appearances, of: namedSet)
             }
     }
 
@@ -41,54 +38,51 @@ final class ColorFinder: ColorFinding {
         let lastColorSetIndex = colorSets.count - 1
 
         for currentColorSetIndex in 0...lastColorSetIndex {
-            let colorSet = colorSets[currentColorSetIndex]
-            let colors = colorSet.colorSet.colors
-            let nextIndex = currentColorSetIndex + 1
+            let currentColorSet = colorSets[currentColorSetIndex]
+            let currentColors = currentColorSet.colorSet.colors
+            let nextColorSetIndex = currentColorSetIndex + 1
 
-            for color in colors {
-                let rgbHex = color.color.rgbHex
+            for currentColor in currentColors {
+                let rgbHex = currentColor.color.rgbHex
 
                 if duplicates.keys.contains(rgbHex) {
                     continue
                 }
-                
+
                 var colorNames: [String] = []
 
-                for otherColor in colorSets[nextIndex...] {
-                    let appearanceNames = findAppearances(
+                for otherColorSet in colorSets[nextColorSetIndex...] {
+                    let otherColorSetAppearances = findAppearances(
                         for: rgbHex,
-                        in: otherColor.colorSet.colors
+                        in: otherColorSet.colorSet.colors
                     )
 
-                    if appearanceNames.isEmpty {
+                    if otherColorSetAppearances.isEmpty {
                         continue
                     }
 
-                    var name = otherColor.name
-
-                    if appearanceNames.count < otherColor.colorSet.colors.count {
-                        name += " (\(joined(appearanceNames)))"
-                    }
-
+                    let name = makeColorName(
+                        from: otherColorSetAppearances,
+                        of: otherColorSet
+                    )
                     colorNames.append(name)
                 }
 
+                // If at least one duplicate found, add the searched name too
                 if !colorNames.isEmpty {
                     let currentColorSetAppearances = findAppearances(
                         for: rgbHex,
-                        in: colors
+                        in: currentColors
                     )
                     
                     if currentColorSetAppearances.isEmpty {
                         break
                     }
 
-                    var currentColorSetName = colorSet.name
-
-                    if currentColorSetAppearances.count < colors.count {
-                        currentColorSetName += " (\(joined(currentColorSetAppearances)))"
-                    }
-
+                    let currentColorSetName = makeColorName(
+                        from: currentColorSetAppearances,
+                        of: currentColorSet
+                    )
                     colorNames.append(currentColorSetName)
 
                     if duplicates[rgbHex] == nil {
@@ -131,5 +125,13 @@ extension ColorFinder {
 
     private func joined(_ appearances: [String]) -> String {
         appearances.joined(separator: ", ")
+    }
+
+    private func makeColorName(from appearances: [String], of namedColorSet: NamedColorSet) -> String {
+        if appearances.count < namedColorSet.colorSet.colors.count {
+            return "\(namedColorSet.name) (\(joined(appearances)))"
+        } else {
+            return namedColorSet.name
+        }
     }
 }

--- a/Sources/hexcode/HexcodeApp.swift
+++ b/Sources/hexcode/HexcodeApp.swift
@@ -21,11 +21,12 @@ final class HexcodeApp {
         self.assetCollector = assetCollector
     }
 
-    /// Entry point for `hexcode` app logic.
-    /// - parameter colorHex: Raw input argument for hexadecimal color code.
-    /// - parameter directory: Optional custom directory from user input. Defaults to current directory.
+    /// Entry point for the default `find-color` subcommand logic.
+    /// - Parameters:
+    ///   - colorHex: Raw input argument for hexadecimal color code.
+    ///   - directory: Optional custom directory from user input. Defaults to current directory.
     /// - throws: All unhandled errors that can be thrown out to standard output.
-    func run(colorHex: String, in directory: String? = nil) async throws {
+    func runFindColor(colorHex: String, in directory: String? = nil) async throws {
         let directory = directory ?? fileManager.currentDirectoryPath
         let colorAssets = try await assetCollector.collectAssets(in: directory)
         let foundColors = colorFinder.find(colorHex, in: colorAssets)
@@ -36,5 +37,15 @@ final class HexcodeApp {
         }
 
         foundColors.forEach { output($0) }
+    }
+
+
+    /// Entry point for the `find-duplicates` subcommand logic.
+    /// - Parameter directory: Optional custom directory from user input. Defaults to current directory.
+    /// - throws: All unhandled errors that can be thrown out to standard output.
+    func runFindDuplicates(in directory: String? = nil) async throws {
+        let directory = directory ?? fileManager.currentDirectoryPath
+        // TODO: Ipmlememnt underlying logic of the "find-duplicates" command
+        output("No duplicates found")
     }
 }

--- a/Sources/hexcode/HexcodeApp.swift
+++ b/Sources/hexcode/HexcodeApp.swift
@@ -45,7 +45,21 @@ final class HexcodeApp {
     /// - throws: All unhandled errors that can be thrown out to standard output.
     func runFindDuplicates(in directory: String? = nil) async throws {
         let directory = directory ?? fileManager.currentDirectoryPath
-        // TODO: Ipmlememnt underlying logic of the "find-duplicates" command
-        output("No duplicates found")
+        let colorAssets = try await assetCollector.collectAssets(in: directory)
+        let foundDuplicates = colorFinder.findDuplicates(in: colorAssets)
+
+        if foundDuplicates.isEmpty {
+            output("No duplicates found")
+            return
+        }
+
+        foundDuplicates
+            .sorted { $0.key < $1.key }
+            .forEach { duplicate in
+
+            duplicate.value.forEach { color in
+                output("#\(duplicate.key) \(color)")
+            }
+        }
     }
 }

--- a/Sources/hexcode/HexcodeApp.swift
+++ b/Sources/hexcode/HexcodeApp.swift
@@ -53,13 +53,22 @@ final class HexcodeApp {
             return
         }
 
+        var hasMoreThanOneDuplicate = false
         foundDuplicates
             .sorted { $0.key < $1.key }
             .forEach { duplicate in
 
-            duplicate.value.forEach { color in
-                output("#\(duplicate.key) \(color)")
+                if hasMoreThanOneDuplicate {
+                    output("--")
+                }
+
+                duplicate.value.forEach { color in
+                    output("#\(duplicate.key) \(color)")
+                }
+
+                if !hasMoreThanOneDuplicate {
+                    hasMoreThanOneDuplicate = true
+                }
             }
-        }
     }
 }

--- a/Tests/hexcodeTests/AssetCollectorTests.swift
+++ b/Tests/hexcodeTests/AssetCollectorTests.swift
@@ -83,16 +83,20 @@ final class AssetCollectorTests: XCTestCase {
         let otherColorsDir = catalogPath + "/OtherColors"
         setMockDirectory(at: otherColorsDir, with: ["more_colors", "greenColorHex.colorset"])
         setMockAsset(at: "\(otherColorsDir)/greenColorHex.colorset", with: ColorSetJSON.green)
+        var greenColorHex: NamedColorSet = .greenColorHex
+        greenColorHex.name = "OtherColors/greenColorHex"
 
         let moreColorsDir = otherColorsDir + "/more_colors"
         setMockDirectory(at: moreColorsDir, with: ["blueColorHex.colorset"])
         setMockAsset(at: "\(moreColorsDir)/blueColorHex.colorset", with: ColorSetJSON.blue)
+        var blueColorHex: NamedColorSet = .blueColorHex
+        blueColorHex.name = "OtherColors/more_colors/blueColorHex"
 
         // When
         let assets = try await sut.collectAssets(in: catalogPath)
 
         // Then
-        XCTAssertEqual(assets, [.blueColorHex, .greenColorHex, .redColorHex])
+        XCTAssertEqual(assets, [greenColorHex, blueColorHex, .redColorHex])
     }
 }
 

--- a/Tests/hexcodeTests/ColorFinderTests.swift
+++ b/Tests/hexcodeTests/ColorFinderTests.swift
@@ -195,4 +195,36 @@ final class ColorFinderTests: XCTestCase {
         // Then
         AssertEmpty(colors)
     }
+
+    func test_findDuplicates_inColorSetWithInvalidColors_returnsEmptyDictionary() {
+        // Given
+        let invalidColor = ColorSet(
+            colors: [
+                .init(
+                    color: .init(
+                        colorSpace: .srgb,
+                        components: .init(
+                            alpha: "0",
+                            red: "r",
+                            green: "g",
+                            blue: "b"
+                        )
+                    ),
+                    idiom: .iPhone
+                )
+            ],
+            info: .init(author: "-", version: 1.0)
+        )
+        let colorSets: [NamedColorSet] = [
+            .init(name: "one", colorSet: invalidColor),
+            .init(name: "two", colorSet: invalidColor),
+        ]
+
+        // When
+        let colors = sut.findDuplicates(in: colorSets)
+
+        // Then
+        AssertEmpty(colors)
+    }
+
 }

--- a/Tests/hexcodeTests/ColorFinderTests.swift
+++ b/Tests/hexcodeTests/ColorFinderTests.swift
@@ -131,7 +131,7 @@ final class ColorFinderTests: XCTestCase {
 
     // MARK: - Test find duplicates
 
-    func test_findDuplicates_inColorSetsWithMulticolorDuplicate_findsExpectedDuplicates() {
+    func test_findDuplicates_inColorSetsWithMulticolorDuplicate_findsExpectedDuplicateValues() {
         // When
         let duplicates = sut.findDuplicates(in: [.defaultTextColorHex, .brandBlackColorHex])
 
@@ -139,18 +139,60 @@ final class ColorFinderTests: XCTestCase {
         XCTAssertEqual(duplicates, ["171717": ["brandBlackColorHex", "defaultTextHex (Any, Light)"]])
     }
 
-    func test_findDuplicates_inColorSetsWithSingularDuplicates_findsExpectedDuplicates() {
+    func test_findDuplicates_inColorSetsWithSingularDuplicate_findsExpectedDuplicateValues() {
         // Given
         let duplicatedWhite = NamedColorSet(
             name: "duplicatedWhite",
             colorSet: .Universal.Singular.white
         )
-        let colorSets = [.whiteColorHex, .blackColorHex, duplicatedWhite]
+        let colorSets: [NamedColorSet] = [.whiteColorHex, .blackColorHex, duplicatedWhite]
 
         // When
         let colors = sut.findDuplicates(in: colorSets)
 
         // Then
         XCTAssertEqual(colors, ["FFFFFF": ["duplicatedWhite", "whiteColorHex"]])
+    }
+
+    func test_findDuplicates_inColorSetsWithMultipleDuplicates_returnsSortedExpectedDuplicateValues() {
+        // Given
+        var yellow: NamedColorSet = .sunflowerColorHex
+        yellow.name = "yellow"
+
+        var snowWhite: NamedColorSet = .whiteColorHex
+        snowWhite.name = "snowWhite"
+
+        let colorSets: [NamedColorSet] = [
+            .blueColorHex,
+            .sunflowerColorHex,
+            .whiteColorHex,
+            .blackColorHex,
+            yellow,
+            .redColorHex,
+            snowWhite,
+            .greenColorHex,
+            .defaultTextColorHex,
+        ]
+
+        // When
+        let colors = sut.findDuplicates(in: colorSets)
+
+        // Then
+        XCTAssertEqual(colors, [
+            "F4EA2F": ["sunflowerHex (Dark)", "yellow (Dark)"],
+            "FFFFFF": ["snowWhite", "whiteColorHex"],
+            "E8DE2A": ["sunflowerHex (Any)", "yellow (Any)"],
+        ])
+    }
+
+    func test_findDuplicates_inColorSetWithNoDuplicates_returnsEmptyDictionary() {
+        // Given
+        let colorSets: [NamedColorSet] = [.redColorHex, .greenColorHex, .blueColorHex]
+
+        // When
+        let colors = sut.findDuplicates(in: colorSets)
+
+        // Then
+        AssertEmpty(colors)
     }
 }

--- a/Tests/hexcodeTests/ColorFinderTests.swift
+++ b/Tests/hexcodeTests/ColorFinderTests.swift
@@ -128,4 +128,29 @@ final class ColorFinderTests: XCTestCase {
         // Then
         XCTAssertEqual(colors, ["cyanColorHex"])
     }
+
+    // MARK: - Test find duplicates
+
+    func test_findDuplicates_inColorSetsWithMulticolorDuplicate_findsExpectedDuplicates() {
+        // When
+        let duplicates = sut.findDuplicates(in: [.defaultTextColorHex, .brandBlackColorHex])
+
+        // Then
+        XCTAssertEqual(duplicates, ["171717": ["brandBlackColorHex", "defaultTextHex (Any, Light)"]])
+    }
+
+    func test_findDuplicates_inColorSetsWithSingularDuplicates_findsExpectedDuplicates() {
+        // Given
+        let duplicatedWhite = NamedColorSet(
+            name: "duplicatedWhite",
+            colorSet: .Universal.Singular.white
+        )
+        let colorSets = [.whiteColorHex, .blackColorHex, duplicatedWhite]
+
+        // When
+        let colors = sut.findDuplicates(in: colorSets)
+
+        // Then
+        XCTAssertEqual(colors, ["FFFFFF": ["duplicatedWhite", "whiteColorHex"]])
+    }
 }

--- a/Tests/hexcodeTests/ColorFinderTests.swift
+++ b/Tests/hexcodeTests/ColorFinderTests.swift
@@ -227,4 +227,72 @@ final class ColorFinderTests: XCTestCase {
         AssertEmpty(colors)
     }
 
+    // MARK: - Test performance
+
+#if !CI
+    func test_performance_findDuplicates_measureSpeed() {
+        // Given
+        let repeatingColorSets: [NamedColorSet] = Array(repeating: .blueColorHex, count: 10)
+        + Array(repeating: .redColorHex, count: 10)
+        + Array(repeating: .greenColorHex, count: 10)
+        + Array(repeating: .blackColorHex, count: 10)
+        + Array(repeating: .whiteColorHex, count: 10)
+        + Array(repeating: .cyanColorHex, count: 10)
+        + Array(repeating: .brandBlackColorHex, count: 10)
+        + Array(repeating: .defaultTextColorHex, count: 10)
+        + Array(repeating: .sunflowerColorHex, count: 10)
+        + Array(repeating: .cyanColorHex, count: 10)
+
+        let allDifferentColorSets: [NamedColorSet] = (0..<255).map {
+            NamedColorSet(
+                name: "\($0) colorset",
+                colorSet: ColorSet(
+                    colors: [
+                        ColorAsset(
+                            color: .init(
+                                colorSpace: .srgb,
+                                components: .init(
+                                    alpha: "0xFF",
+                                    red: String(format: "0x%02X", $0),
+                                    green: "0x00",
+                                    blue: "0xFF"
+                                )
+                            ),
+                            idiom: .iPhone
+                        )
+                    ],
+                    info: .init(author: "author", version: 1.0)
+                )
+            )
+        }
+
+        var repeatingColorSetResults: [String: [String]] = [:]
+        var allDifferentColorSetResults: [String: [String]] = [:]
+
+        // Then
+        self.measure {
+            // When
+            repeatingColorSetResults = sut.findDuplicates(in: repeatingColorSets)
+            allDifferentColorSetResults = sut.findDuplicates(in: allDifferentColorSets)
+        }
+
+        // Then
+        XCTAssertEqual(
+            repeatingColorSetResults,
+            [
+                "000000": Array(repeating: "blackColorHex", count: 10),
+                "FFFFFF": Array(repeating: "whiteColorHex", count: 10),
+                "FF0000": Array(repeating: "redColorHex", count: 10),
+                "00FF00": Array(repeating: "greenColorHex", count: 10),
+                "E7E7E7": Array(repeating: "defaultTextHex (Dark)", count: 10),
+                "F4EA2F": Array(repeating: "sunflowerHex (Dark)", count: 10),
+                "00FFFF": Array(repeating: "cyanColorHex", count: 20),
+                "0000FF": Array(repeating: "blueColorHex", count: 10),
+                "171717": Array(repeating: "brandBlackColorHex", count: 10) + Array(repeating: "defaultTextHex (Any, Light)", count: 10),
+                "E8DE2A": Array(repeating: "sunflowerHex (Any)", count: 10)
+            ]
+        )
+        AssertEmpty(allDifferentColorSetResults)
+    }
+#endif
 }

--- a/Tests/hexcodeTests/HexcodeAppTests.swift
+++ b/Tests/hexcodeTests/HexcodeAppTests.swift
@@ -43,7 +43,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.fileManager.results.currentDirectoryPath = currentDirectory
 
         // When
-        try await sut.run(colorHex: "")
+        try await sut.runFindColor(colorHex: "")
 
         // Then
         XCTAssertEqual(mocks.fileManager.calls, [.getCurrentDirectoryPath])
@@ -55,7 +55,7 @@ final class HexcodeAppTests: XCTestCase {
         let searchDirectory = "/searchDirectory"
 
         // When
-        try await sut.run(colorHex: "", in: searchDirectory)
+        try await sut.runFindColor(colorHex: "", in: searchDirectory)
 
         // Then
         XCTAssertEqual(mocks.assetCollector.calls, [.collectAssetsIn(directory: searchDirectory)])
@@ -66,7 +66,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.notADirectory)
 
         await AssertAsync(
-            try await sut.run(colorHex: blackHexStub), // When
+            try await sut.runFindColor(colorHex: blackHexStub), // When
             throwsError: AssetCollector.Error.notADirectory // Then
         )
     }
@@ -76,7 +76,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.directoryNotFound)
 
         await AssertAsync(
-            try await sut.run(colorHex: blackHexStub), // When
+            try await sut.runFindColor(colorHex: blackHexStub), // When
             throwsError: AssetCollector.Error.directoryNotFound // Then
         )
     }
@@ -86,7 +86,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.notADirectory)
 
         // When
-        try? await sut.run(colorHex: blackHexStub)
+        try? await sut.runFindColor(colorHex: blackHexStub)
 
         // Then
         AssertEmpty(mocks.colorFinder.calls)
@@ -98,7 +98,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .failure(AssetCollector.Error.directoryNotFound)
 
         // When
-        try? await sut.run(colorHex: blackHexStub)
+        try? await sut.runFindColor(colorHex: blackHexStub)
 
         // Then
         AssertEmpty(mocks.colorFinder.calls)
@@ -116,7 +116,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .success(expectedColorSets)
 
         // When
-        try await sut.run(colorHex: colorHex)
+        try await sut.runFindColor(colorHex: colorHex)
 
         // Then
         XCTAssertEqual(
@@ -131,7 +131,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.assetCollector.results.collectAssets = .success([])
 
         // When
-        try await sut.run(colorHex: colorHex)
+        try await sut.runFindColor(colorHex: colorHex)
 
         // Then
         XCTAssertEqual(
@@ -146,7 +146,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.colorFinder.results.find = [expectedOutput]
 
         // When
-        try await sut.run(colorHex: "")
+        try await sut.runFindColor(colorHex: "")
 
         // Then
         XCTAssertEqual(mocks.outputs, [expectedOutput])
@@ -158,7 +158,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.colorFinder.results.find = expectedOutputs
 
         // When
-        try await sut.run(colorHex: "")
+        try await sut.runFindColor(colorHex: "")
 
         // Then
         XCTAssertEqual(mocks.outputs, expectedOutputs)
@@ -169,7 +169,7 @@ final class HexcodeAppTests: XCTestCase {
         mocks.colorFinder.results.find = []
 
         // When
-        try await sut.run(colorHex: blackHexStub)
+        try await sut.runFindColor(colorHex: blackHexStub)
 
         // Then
         XCTAssertEqual(mocks.outputs, ["No \(blackHexStub) color found"])

--- a/Tests/hexcodeTests/Mocks/ColorFinderMock.swift
+++ b/Tests/hexcodeTests/Mocks/ColorFinderMock.swift
@@ -3,10 +3,12 @@
 final class ColorFinderMock {
     enum Call: Equatable {
         case find(hex: String, colorSets: [NamedColorSet])
+        case findDuplicates(in: [NamedColorSet])
     }
 
     struct CallResults {
         var find: [String] = []
+        var findDuplicates: [String: [String]] = [:]
     }
 
     private(set) var calls: [Call] = []
@@ -24,5 +26,10 @@ extension ColorFinderMock: ColorFinding {
     func find(_ hex: String, in colorSets: [NamedColorSet]) -> [String] {
         calls.append(.find(hex: hex, colorSets: colorSets))
         return results.find
+    }
+
+    func findDuplicates(in colorSets: [NamedColorSet]) -> [String: [String]] {
+        calls.append(.findDuplicates(in: colorSets))
+        return results.findDuplicates
     }
 }

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/OtherColors/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/OtherColors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/OtherColors/lavenderHex.colorset/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/OtherColors/lavenderHex.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xE6",
+          "red" : "0xE6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/OtherColors/palePurpleHex.colorset/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/OtherColors/palePurpleHex.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xE6",
+          "red" : "0xE6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/caribbeanSeaHex.colorset/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/caribbeanSeaHex.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9D",
+          "green" : "0x81",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/darkSunflowerDuplicateHex.colorset/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/darkSunflowerDuplicateHex.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0xEA",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/lavender.colorset/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/lavender.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "250",
+          "green" : "230",
+          "red" : "230"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/sunflowerDuplicateHex.colorset/Contents.json
+++ b/Tests/hexcodeTests/Resources/AssetsWithDuplicates.xcassets/sunflowerDuplicateHex.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2A",
+          "green" : "0xDE",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0xEA",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/hexcodeTests/Stubs/ColorSet+Stubs.swift
+++ b/Tests/hexcodeTests/Stubs/ColorSet+Stubs.swift
@@ -7,6 +7,7 @@ extension ColorSet {
         enum Singular {
             static let white = makeColorSet(red: "0xFF", green: "0xFF", blue: "0xFF")
             static let black = makeColorSet(red: "0x00", green: "0x00", blue: "0x00")
+            static let brandBlack = makeColorSet(red: "0x17", green: "0x17", blue: "0x17")
             static let red = makeColorSet(red: "0xFF", green: "0x00", blue: "0x00")
             static let green = makeColorSet(red: "0x00", green: "0xFF", blue: "0x00")
             static let blue = makeColorSet(red: "0x00", green: "0x00", blue: "0xFF")

--- a/Tests/hexcodeTests/Stubs/NamedColorSet+Stubs.swift
+++ b/Tests/hexcodeTests/Stubs/NamedColorSet+Stubs.swift
@@ -36,6 +36,11 @@ extension NamedColorSet {
         colorSet: .Universal.Multiple.defaultText
     )
 
+    static let brandBlackColorHex: Self = NamedColorSet(
+        name: "brandBlackColorHex",
+        colorSet: .Universal.Singular.brandBlack
+    )
+
     static let cyanColorHex: Self = NamedColorSet(
         name: "cyanColorHex",
         colorSet: .Universal.Multiple.cyan

--- a/Tests/hexcodeTests/hexcodeEndToEndTests.swift
+++ b/Tests/hexcodeTests/hexcodeEndToEndTests.swift
@@ -186,6 +186,21 @@ final class HexcodeEndToEndTests: XCTestCase {
         XCTAssertEqual(error, "")
     }
 
+    func test_hexcode_findDuplicates_withSingleDuplicate_outputsDuplicateWithoutSeparator() throws {
+        let arguments = ["find-duplicates", "--directory=\(resourcePath)/AssetsWithDuplicates.xcassets/OtherColors"]
+
+        let (output, error) = try runHexcode(arguments: arguments)
+
+        XCTAssertEqual(
+            output,
+            """
+            #E6E6FA lavenderHex
+            #E6E6FA palePurpleHex\n
+            """
+        )
+        XCTAssertEqual(error, "")
+    }
+
     func test_hexcode_findDuplicates_inDicectoryWithoutDuplicates_outputsNoDuplicatesFoundMessage() throws {
         // Given
         let arguments = ["find-duplicates", "--directory=\(resourcePath)/AssetsInSubdirectories.xcassets"]

--- a/Tests/hexcodeTests/hexcodeEndToEndTests.swift
+++ b/Tests/hexcodeTests/hexcodeEndToEndTests.swift
@@ -212,6 +212,18 @@ final class HexcodeEndToEndTests: XCTestCase {
         XCTAssertEqual(output, "No duplicates found\n")
         XCTAssertEqual(error, "")
     }
+
+    func test_hexcode_findDuplicates_inDicectoryWithoutColorAssets_outputsNoDuplicatesFoundMessage() throws {
+        // Given
+        let arguments = ["find-duplicates", "--directory=\(resourcePath)/FakeContentFolder"]
+
+        // When
+        let (output, error) = try runHexcode(arguments: arguments)
+
+        // Then
+        XCTAssertEqual(output, "No duplicates found\n")
+        XCTAssertEqual(error, "")
+    }
 }
 
 // MARK: - Private

--- a/Tests/hexcodeTests/hexcodeEndToEndTests.swift
+++ b/Tests/hexcodeTests/hexcodeEndToEndTests.swift
@@ -72,7 +72,7 @@ final class HexcodeEndToEndTests: XCTestCase {
         let (output, error) = try runHexcode(arguments: arguments)
 
         // Then
-        XCTAssertEqual(output, "blueColorHex\n")
+        XCTAssertEqual(output, "OtherColors/more_colors/blueColorHex\n")
         XCTAssertEqual(error, "")
     }
 
@@ -175,9 +175,9 @@ final class HexcodeEndToEndTests: XCTestCase {
         XCTAssertEqual(
             output,
             """
-            #E6E6FA lavender
             #E6E6FA OtherColors/lavenderHex
             #E6E6FA OtherColors/palePurpleHex
+            #E6E6FA lavender
             --
             #F4EA2F darkSunflowerDuplicateHex
             #F4EA2F sunflowerDuplicateHex (Dark)\n

--- a/Tests/hexcodeTests/hexcodeEndToEndTests.swift
+++ b/Tests/hexcodeTests/hexcodeEndToEndTests.swift
@@ -166,6 +166,37 @@ final class HexcodeEndToEndTests: XCTestCase {
         XCTAssertEqual(output, "")
         XCTAssert(error.contains("Error: Color hex contains invalid symbols\n"))
     }
+
+    func test_hexcode_findDuplicates_withMultipleDuplicates_findsAllDuplicates() throws {
+        let arguments = ["find-duplicates", "--directory=\(resourcePath)/AssetsWithDuplicates.xcassets"]
+
+        let (output, error) = try runHexcode(arguments: arguments)
+
+        XCTAssertEqual(
+            output,
+            """
+            #E6E6FA lavender
+            #E6E6FA OtherColors/lavenderHex
+            #E6E6FA OtherColors/palePurpleHex
+            --
+            #F4EA2F darkSunflowerDuplicateHex
+            #F4EA2F sunflowerDuplicateHex (Dark)\n
+            """
+        )
+        XCTAssertEqual(error, "")
+    }
+
+    func test_hexcode_findDuplicates_inDicectoryWithoutDuplicates_outputsNoDuplicatesFoundMessage() throws {
+        // Given
+        let arguments = ["find-duplicates", "--directory=\(resourcePath)/AssetsInSubdirectories.xcassets"]
+
+        // When
+        let (output, error) = try runHexcode(arguments: arguments)
+
+        // Then
+        XCTAssertEqual(output, "No duplicates found\n")
+        XCTAssertEqual(error, "")
+    }
 }
 
 // MARK: - Private


### PR DESCRIPTION
## In this PR
- bumped `ArgumentParser` dependency version to `1.5.0`
- split the main command into two subcommands, making `find-color` the default one to preserve existing functionality
- added new `find-duplicates` command to enable search for duplicated color assets
- renamed a few of the existing methods to make the difference more explicit
- covered the logic with new unit and end-to-end tests, also committed one of the performance tests
- mentioned updates in README
- bumped the app version to `0.2.0` in the command configuration

## Checklist
Before making this PR ready to merge:
- [x] Checked for duplicate PRs
- [x] If related to one or more existing issues, linked the issues
- [x] Covered new code with unit tests
- [x] Ran the tests and all of them passed
