### PR TITLE
Improve installation process with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ install:
 	if [ -z "$${INSTALLATION_PATH}" ]; then \
 		INSTALLATION_PATH=/usr/local/bin/hexcode ; \
 	fi && \
-	swift build -q -c release ; \
-	install .build/release/hexcode "$${INSTALLATION_PATH}" ; \
+	swift build -q -c release && \
+	install .build/release/hexcode "$${INSTALLATION_PATH}" && \
 	echo "Installed at $${INSTALLATION_PATH}" 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: install
 install:
-	swift build -q -c release
-	install .build/release/hexcode /usr/local/bin/hexcode
-
+	@INSTALLATION_PATH=$$(which hexcode) ; \
+	if [ -z "$${INSTALLATION_PATH}" ]; then \
+		INSTALLATION_PATH=/usr/local/bin/hexcode ; \
+	fi && \
+	swift build -q -c release ; \
+	install .build/release/hexcode "$${INSTALLATION_PATH}" ; \
+	echo "Installed at $${INSTALLATION_PATH}" 

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,11 @@ install:
 	swift build -q -c release && \
 	install .build/release/hexcode "$${INSTALLATION_PATH}" && \
 	echo "Installed at $${INSTALLATION_PATH}" 
+
+.PHONY: uninstall
+uninstall:
+	@rm $$(which hexcode)
+
+.PHONY: clean
+clean:
+	@rm -rf .build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: install
 install:
-	@INSTALLATION_PATH=$$(which hexcode) ; \
+	@INSTALLATION_PATH=$(if $(filter install, $(MAKECMDGOALS)), $(word 2, $(MAKECMDGOALS)), $(which hexcode)) ; \
 	if [ -z "$${INSTALLATION_PATH}" ]; then \
 		INSTALLATION_PATH=/usr/local/bin/hexcode ; \
 	fi && \

--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ Or you can just run it as an executable Swift package [without installation](#ru
 ### Using make:
 From the root of the repository, run the following command:
 ```
-sudo make install
+make install
 ```
-If you want to install it into a directory other than default `/usr/local/bin`, replace it in the `Makefile` with your target directory.
-Just make sure it's added to the PATH.
+With no in stallation path provided, it will try to install `hexcode` to where it's already installed. If this is the first-time installation, the default path is `/usr/local/bin`.  
+
+There's also an option to provide a custom installation path:
+```
+make install </custom/installation/path>
+```
+Just make sure it's added to the PATH or sourced if you want the command to be visible from anywhere without typing the full path to it. Depending on the installation path and current user, `make install` command might need `sudo` access.
 ### Running without installation:
 From the `hexcode` directory (or passing it as `--package-path`), the command can be run as executable package without previous installation, for example:
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ From the root of the repository, run the following command:
 ```
 make install
 ```
-With no in stallation path provided, it will try to install `hexcode` to where it's already installed. If this is the first-time installation, the default path is `/usr/local/bin`.  
+With no installation path provided, it will try to install `hexcode` to where it's already installed. If this is the first-time installation, the default path is `/usr/local/bin`.  
 
 There's also an option to provide a custom installation path:
 ```


### PR DESCRIPTION
## In this PR
- made the `make install` command try installing new version of `hexcode` to where it has been previously installed
- enabled custom installation path with `make install`
- added simple `clean` and `uninstall` helper targets
- mentioned the `make install` update in README

## Checklist
Before making this PR ready to merge:
- [ ] Checked for duplicate PRs
- [ ] If related to one or more existing issues, linked the issues
- [ ] Covered new code with unit tests
- [ ] Ran the tests and all of them passed
