### PR TITLE
Expand tilde in path

### DIFF
--- a/Sources/hexcode/Commands/Hexcode.swift
+++ b/Sources/hexcode/Commands/Hexcode.swift
@@ -10,7 +10,7 @@ struct Hexcode: AsyncParsableCommand {
                   by their hexadecimal codes.
                   """,
         usage: "hexcode <color-hex> [--directory <directory>]",
-        version: "hexcode 0.2.0",
+        version: "hexcode 0.2.1",
         subcommands: [
             FindColor.self,
             FindDuplicates.self,

--- a/Sources/hexcode/HexcodeApp.swift
+++ b/Sources/hexcode/HexcodeApp.swift
@@ -76,6 +76,9 @@ final class HexcodeApp {
 
 extension HexcodeApp {
     private func expandTilde(_ path: String) -> String {
-        (path as NSString).expandingTildeInPath
+        path.replacingOccurrences(
+            of: "~",
+            with: fileManager.homeDirectoryForCurrentUser.relativePath
+        )
     }
 }

--- a/Sources/hexcode/HexcodeApp.swift
+++ b/Sources/hexcode/HexcodeApp.swift
@@ -27,7 +27,7 @@ final class HexcodeApp {
     ///   - directory: Optional custom directory from user input. Defaults to current directory.
     /// - throws: All unhandled errors that can be thrown out to standard output.
     func runFindColor(colorHex: String, in directory: String? = nil) async throws {
-        let directory = directory ?? fileManager.currentDirectoryPath
+        let directory = directory.map(expandTilde) ?? fileManager.currentDirectoryPath
         let colorAssets = try await assetCollector.collectAssets(in: directory)
         let foundColors = colorFinder.find(colorHex, in: colorAssets)
 
@@ -39,12 +39,11 @@ final class HexcodeApp {
         foundColors.forEach { output($0) }
     }
 
-
     /// Entry point for the `find-duplicates` subcommand logic.
     /// - Parameter directory: Optional custom directory from user input. Defaults to current directory.
     /// - throws: All unhandled errors that can be thrown out to standard output.
     func runFindDuplicates(in directory: String? = nil) async throws {
-        let directory = directory ?? fileManager.currentDirectoryPath
+        let directory = directory.map(expandTilde) ?? fileManager.currentDirectoryPath
         let colorAssets = try await assetCollector.collectAssets(in: directory)
         let foundDuplicates = colorFinder.findDuplicates(in: colorAssets)
 
@@ -70,5 +69,13 @@ final class HexcodeApp {
                     hasMoreThanOneDuplicate = true
                 }
             }
+    }
+}
+
+// MARK: - Private
+
+extension HexcodeApp {
+    private func expandTilde(_ path: String) -> String {
+        (path as NSString).expandingTildeInPath
     }
 }

--- a/Tests/hexcodeTests/HexcodeAppTests.swift
+++ b/Tests/hexcodeTests/HexcodeAppTests.swift
@@ -175,17 +175,20 @@ final class HexcodeAppTests: XCTestCase {
         XCTAssertEqual(mocks.outputs, ["No \(blackHexStub) color found"])
     }
 
-    func test_runFindColor_withTildaInPath_expandsTildaToFilePath() async throws {
+    func test_runFindColor_withTildeInPath_expandsTildaToFilePath() async throws {
         // Given
-        let homeDir = try XCTUnwrap(
-            ProcessInfo.processInfo.environment["HOME"]
-        )
+        let homeDir = "/home/dir"
+        let homeURL = try XCTUnwrap(URL(filePath: homeDir))
+        mocks.fileManager.results.homeDirectoryForCurrentUser = homeURL
 
         // When
         try await sut.runFindColor(colorHex: blackHexStub, in: "~/TestProject")
 
 
         // Then
+        XCTAssertEqual(mocks.fileManager.calls, [
+            .getHomeDirectoryForCurrentUser
+        ])
         XCTAssertEqual(mocks.assetCollector.calls, [
             .collectAssetsIn(directory: "\(homeDir)/TestProject")
         ])
@@ -243,17 +246,20 @@ final class HexcodeAppTests: XCTestCase {
         ])
     }
 
-    func test_runFindDuplicates_withTildaInPath_expandsTildaToFilePath() async throws {
+    func test_runFindDuplicates_withTildeInPath_expandsTildaToFilePath() async throws {
         // Given
-        let homeDir = try XCTUnwrap(
-            ProcessInfo.processInfo.environment["HOME"]
-        )
+        let homeDir = "/Users/user"
+        let homeURL = try XCTUnwrap(URL(string: homeDir))
+        mocks.fileManager.results.homeDirectoryForCurrentUser = homeURL
 
         // When
         try await sut.runFindDuplicates(in: "~/documents/project")
 
 
         // Then
+        XCTAssertEqual(mocks.fileManager.calls, [
+            .getHomeDirectoryForCurrentUser
+        ])
         XCTAssertEqual(mocks.assetCollector.calls, [
             .collectAssetsIn(directory: "\(homeDir)/documents/project")
         ])

--- a/Tests/hexcodeTests/HexcodeAppTests.swift
+++ b/Tests/hexcodeTests/HexcodeAppTests.swift
@@ -175,6 +175,22 @@ final class HexcodeAppTests: XCTestCase {
         XCTAssertEqual(mocks.outputs, ["No \(blackHexStub) color found"])
     }
 
+    func test_runFindColor_withTildaInPath_expandsTildaToFilePath() async throws {
+        // Given
+        let homeDir = try XCTUnwrap(
+            ProcessInfo.processInfo.environment["HOME"]
+        )
+
+        // When
+        try await sut.runFindColor(colorHex: blackHexStub, in: "~/TestProject")
+
+
+        // Then
+        XCTAssertEqual(mocks.assetCollector.calls, [
+            .collectAssetsIn(directory: "\(homeDir)/TestProject")
+        ])
+    }
+
     // MARK: Test runFindDuplicates
 
     func test_runFindDuplicates_whenSingleDuplicateFound_outputsDuplicateHexAndAssetNames() async throws {
@@ -224,6 +240,22 @@ final class HexcodeAppTests: XCTestCase {
             "#FFFFFF black",
             "#FFFFFF darkestHex",
             "#FFFFFF text (Any, Light)",
+        ])
+    }
+
+    func test_runFindDuplicates_withTildaInPath_expandsTildaToFilePath() async throws {
+        // Given
+        let homeDir = try XCTUnwrap(
+            ProcessInfo.processInfo.environment["HOME"]
+        )
+
+        // When
+        try await sut.runFindDuplicates(in: "~/documents/project")
+
+
+        // Then
+        XCTAssertEqual(mocks.assetCollector.calls, [
+            .collectAssetsIn(directory: "\(homeDir)/documents/project")
         ])
     }
 }

--- a/Tests/hexcodeTests/Mocks/FileManagerMock.swift
+++ b/Tests/hexcodeTests/Mocks/FileManagerMock.swift
@@ -10,6 +10,7 @@ final class FileManagerMock: FileManager {
     enum Call: Equatable {
         case getCurrentDirectoryPath
         case setCurrentDirectoryPath(String)
+        case getHomeDirectoryForCurrentUser
         case fileExists(path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?)
         case contentsOfDirectory(path: String)
         case contents(path: String)
@@ -17,6 +18,7 @@ final class FileManagerMock: FileManager {
 
     struct CallResults {
         var currentDirectoryPath: String = ""
+        var homeDirectoryForCurrentUser: URL = .init(filePath: "")
         var fileExistsAtPath: [String: PathContent] = [:]
         var contentsOfDirectory: [String: Result<[String], Error>] = [:]
         var contentsAtPath: [String: Data] = [:]
@@ -57,6 +59,13 @@ extension FileManagerMock {
 
         set {
             calls.append(.setCurrentDirectoryPath(newValue))
+        }
+    }
+
+    override var homeDirectoryForCurrentUser: URL {
+        get {
+            calls.append(.getHomeDirectoryForCurrentUser)
+            return results.homeDirectoryForCurrentUser
         }
     }
 


### PR DESCRIPTION
## In this PR
- made the app understand tilde (`~`) in the file path as home directory for both `find-color` and `find-duplicates` subcommands
- bumped the app version to `0.2.1` in the command configuration

## Checklist
Before making this PR ready to merge:
- [x] Checked for duplicate PRs
- [x] If related to one or more existing issues, linked the issues
- [x] Covered new code with unit tests
- [x] Ran the tests and all of them passed
